### PR TITLE
Update cron schedule to include the 11th

### DIFF
--- a/.github/workflows/update-uf-data.yml
+++ b/.github/workflows/update-uf-data.yml
@@ -3,7 +3,7 @@ name: Update UF Data
 on:
   schedule:
     # Run on the 9th and 10th of each month at 12:00 PM UTC
-    - cron: '0 12 9,10 * *'
+    - cron: '0 12 9,10,11 * *'
   workflow_dispatch: # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
This pull request makes a minor update to the workflow schedule for updating UF Data. The workflow will now also run on the 11th of each month, in addition to the previous dates.

* Changed the cron schedule in `.github/workflows/update-uf-data.yml` to run the workflow on the 9th, 10th, and 11th of each month at 12:00 PM UTC.